### PR TITLE
Refactor: Update pulse pressure logic for differential effects

### DIFF
--- a/solvers/pressure_HR_Oxy.py
+++ b/solvers/pressure_HR_Oxy.py
@@ -285,8 +285,7 @@ class PressureHROxySolver(Solver):
         systolic_new = systolic_old + (systolic_rate_of_change + systolic_change_epi) * dt_seconds
 
         # Diastolic Pressure Calculation
-        base_diastolic_reference = 70.0 # Could be a parameter
-        diastolic_target = base_diastolic_reference + self.svr_to_diastolic_factor * (self.svr - 1.0) # Assuming SVR default/baseline is 1.0
+        diastolic_target = self.base_diastolic_reference + self.svr_to_diastolic_factor * (self.svr - 1.0) # Assuming SVR default/baseline is 1.0
         diastolic_change_potential = diastolic_target - diastolic_old
         diastolic_change_epi = (self.epi_bp_factor / 2) * epi
         diastolic_rate_of_change = diastolic_change_potential / (self.compliance * 5.0) # Factor 5 is for tuning

--- a/solvers/pressure_HR_Oxy.py
+++ b/solvers/pressure_HR_Oxy.py
@@ -107,7 +107,8 @@ class PressureHROxySolver(Solver):
         systemic_vascular_resistance: float = 1.0,
         baroreflex_gain: float = 0.1,
         map_setpoint: float = 90.0,
-        pulse_pressure_factor: float = 0.4,  # Factor to determine pulse pressure
+        sv_to_systolic_factor: float = 0.5,  # unit: mmHg/mL
+        svr_to_diastolic_factor: float = 50.0,  # unit: mmHg/SVR unit
         oxy_recovery_rate: float = 0.01,
         oxy_drop_rate: float = 0.02,
         epi_hr_factor: float = 0.5,
@@ -140,7 +141,8 @@ class PressureHROxySolver(Solver):
         :param systemic_vascular_resistance: The effective afterload.
         :param baroreflex_gain: How strongly HR is adjusted based on difference from map_setpoint.
         :param map_setpoint: The target MAP for baroreflex.
-        :param pulse_pressure_factor: Determines ratio of systolic/diastolic changes.
+        :param sv_to_systolic_factor: Factor converting stroke volume to systolic pressure changes.
+        :param svr_to_diastolic_factor: Factor converting SVR to diastolic pressure changes.
         :param oxy_recovery_rate: Rate at which O2 sat returns to normal if perfusion is adequate.
         :param oxy_drop_rate: Rate at which O2 sat drops if MAP is too low.
         :param epi_hr_factor: How strongly epinephrine from global state raises HR.
@@ -169,7 +171,8 @@ class PressureHROxySolver(Solver):
         self.svr = systemic_vascular_resistance
         self.baro_gain = baroreflex_gain
         self.map_setpoint = map_setpoint
-        self.pulse_pressure_factor = pulse_pressure_factor
+        self.sv_to_systolic_factor = sv_to_systolic_factor
+        self.svr_to_diastolic_factor = svr_to_diastolic_factor
         self.oxy_recovery_rate = oxy_recovery_rate
         self.oxy_drop_rate = oxy_drop_rate
         self.epi_hr_factor = epi_hr_factor
@@ -274,33 +277,44 @@ class PressureHROxySolver(Solver):
         # Clamp stroke volume to physiological limits
         stroke_volume_actual = max(5.0, min(stroke_volume_calculated, self.max_stroke_volume))
 
-        cardiac_output = (hr_old / 60) * stroke_volume_actual # Convert HR to BPS for consistent time units
-        dmap_dt = (cardiac_output - (map_old / self.svr)) / self.compliance
-        
-        # Add epinephrine effect on blood pressure (vasoconstriction)
-        dmap_dt += epi * self.epi_bp_factor
-        
-        # Calculate base MAP change
-        map_change = dmap_dt * dt_seconds
-        
-        # Distribute the change between systolic and diastolic
-        # Systolic changes more than diastolic based on pulse_pressure_factor
-        systolic_change = map_change * (1 + self.pulse_pressure_factor)
-        diastolic_change = map_change * (1 - self.pulse_pressure_factor)
-        
-        # Apply changes
-        systolic_new = systolic_old + systolic_change
-        diastolic_new = diastolic_old + diastolic_change
-        
-        # Enforce limits on systolic and diastolic
+        # Systolic Pressure Calculation
+        systolic_target = diastolic_old + self.sv_to_systolic_factor * stroke_volume_actual
+        systolic_change_potential = systolic_target - systolic_old
+        systolic_change_epi = (self.epi_bp_factor / 2) * epi 
+        systolic_rate_of_change = systolic_change_potential / (self.compliance * 5.0) # Factor 5 is for tuning
+        systolic_new = systolic_old + (systolic_rate_of_change + systolic_change_epi) * dt_seconds
+
+        # Diastolic Pressure Calculation
+        base_diastolic_reference = 70.0 # Could be a parameter
+        diastolic_target = base_diastolic_reference + self.svr_to_diastolic_factor * (self.svr - 1.0) # Assuming SVR default/baseline is 1.0
+        diastolic_change_potential = diastolic_target - diastolic_old
+        diastolic_change_epi = (self.epi_bp_factor / 2) * epi
+        diastolic_rate_of_change = diastolic_change_potential / (self.compliance * 5.0) # Factor 5 is for tuning
+        diastolic_new = diastolic_old + (diastolic_rate_of_change + diastolic_change_epi) * dt_seconds
+
+        # Apply constraints and recalculate MAP
         systolic_new = max(min(systolic_new, self.max_systolic), self.min_systolic)
         diastolic_new = max(min(diastolic_new, self.max_diastolic), self.min_diastolic)
         
-        # Ensure diastolic is always less than systolic
-        if diastolic_new >= systolic_new:
-            diastolic_new = systolic_new - 10  # Minimum 10 mmHg pulse pressure
+        min_pulse_pressure = 10.0
+        if (systolic_new - diastolic_new) < min_pulse_pressure:
+            deficit = min_pulse_pressure - (systolic_new - diastolic_new)
+            adjust_sbp = deficit / 2.0
+            adjust_dbp = -deficit / 2.0
+
+            temp_sbp = systolic_new + adjust_sbp
+            temp_dbp = diastolic_new + adjust_dbp
+
+            systolic_new = max(min(temp_sbp, self.max_systolic), self.min_systolic)
+            diastolic_new = max(min(temp_dbp, self.max_diastolic), self.min_diastolic)
+
+            if (systolic_new - diastolic_new) < min_pulse_pressure:
+                diastolic_new = systolic_new - min_pulse_pressure
+                diastolic_new = max(min(diastolic_new, self.max_diastolic), self.min_diastolic)
+                if (systolic_new - diastolic_new) < min_pulse_pressure:
+                    systolic_new = diastolic_new + min_pulse_pressure
+                    systolic_new = max(min(systolic_new, self.max_systolic), self.min_systolic)
         
-        # Calculate new MAP based on new systolic and diastolic
         map_new = (systolic_new + 2 * diastolic_new) / 3
 
         """
@@ -365,9 +379,9 @@ class PressureHROxySolver(Solver):
 
         logger.debug(
             f"PressureHROxySolver:\n"
-            f"  Systolic BP: {systolic_old:.2f} -> {systolic_new:.2f}\n"
-            f"  Diastolic BP: {diastolic_old:.2f} -> {diastolic_new:.2f}\n"
-            f"  MAP: {map_old:.2f} -> {map_new:.2f}, dMAP/dt={dmap_dt:.3f}\n"
+            f"  Systolic BP: {systolic_old:.2f} -> {systolic_new:.2f} (Target: {systolic_target:.2f})\n"
+            f"  Diastolic BP: {diastolic_old:.2f} -> {diastolic_new:.2f} (Target: {diastolic_target:.2f})\n"
+            f"  MAP: {map_old:.2f} -> {map_new:.2f}\n"
             f"  HR: {hr_old:.1f} -> {hr_new:.1f}, dHR/dt={dhr_dt:.3f}, Epi={epi:.2f}\n"
             f"  PAO2: {pao2:.2f} mmHg (FiO2: {current_fio2:.2f}, RR: {current_rr:.1f}, TV: {current_tv:.2f}L)\n"
             f"  O2 Sat: {oxy_old:.1f}% -> {oxy_new:.1f}%\n"

--- a/tests/test_pressure_hr_oxy_solver.py
+++ b/tests/test_pressure_hr_oxy_solver.py
@@ -13,11 +13,12 @@ class TestPressureHROxySolver(unittest.TestCase):
         return (systolic + 2 * diastolic) / 3
 
     def test_baseline_stability(self):
-        solver = PressureHROxySolver() # Default parameters
+        solver = PressureHROxySolver() # Uses default sv_to_systolic_factor=0.5, svr_to_diastolic_factor=50.0
         initial_hr = 75.0
-        initial_systolic = 120.0
-        initial_diastolic = 80.0
-        initial_edv = solver.target_edv # Should be 120.0 by default
+        initial_systolic = 115.0 # Start SBP
+        initial_diastolic = 75.0  # Start DBP
+        initial_map = self._get_map(initial_systolic, initial_diastolic) # Approx 88.33
+        initial_edv = solver.target_edv # 120.0
 
         initial_data = {
             "systolic_bp": initial_systolic,
@@ -27,49 +28,54 @@ class TestPressureHROxySolver(unittest.TestCase):
             "end_diastolic_volume": initial_edv,
             "oxygen_debt": 0.0
         }
-        # Initial MAP should be the setpoint for stability
-        # The solver's internal map_setpoint is 90.0.
-        # Our initial SBP/DBP (120/80) gives MAP = (120 + 2*80)/3 = 280/3 = 93.33
-        # Let's adjust initial SBP/DBP to actually match the solver's map_setpoint (90)
-        # If MAP = 90, SBP = 110, DBP = 80 => (110 + 160)/3 = 270/3 = 90
-        initial_systolic_at_setpoint = 110.0
-        initial_diastolic_at_setpoint = 80.0
-        initial_data["systolic_bp"] = initial_systolic_at_setpoint
-        initial_data["diastolic_bp"] = initial_diastolic_at_setpoint
         
-        # With edv = target_edv and map_old = map_setpoint, stroke_volume_calculated should be base_stroke_volume
-        # dmap_dt should be (hr * base_sv - map_setpoint/svr) / compliance
-        # If hr * base_sv = map_setpoint/svr, then dmap_dt = 0 and MAP is stable.
-        # Default: base_sv=70, hr=75 (1.25bps), CO = 87.5. svr=1. map_setpoint/svr = 90. CO != map_setpoint/svr.
-        # So MAP will change. HR will also change due to baroreflex. EDV will also change if filling_ratio != 1.
-
         dt = 1.0
-        new_state_obj = solver.solve(initial_data.copy(), dt) # Use copy to avoid modification
+
+        # Calculate expected SV (preload and afterload effects should be minimal here if MAP is close to setpoint)
+        # SV = base_sv + k_preload*(edv - target_edv) - k_afterload*(map_old - map_setpoint)
+        # SV = 70 + 0.5*(120-120) - 0.3*(88.33 - 90) = 70 - 0.3*(-1.67) = 70 + 0.5 = 70.5
+        expected_sv = solver.base_stroke_volume + \
+                      solver.k_preload * (initial_edv - solver.target_edv) - \
+                      solver.k_afterload * (initial_map - solver.map_setpoint)
+        expected_sv = max(5.0, min(expected_sv, solver.max_stroke_volume))
+
+
+        # Expected targets
+        # systolic_target = diastolic_old + sv_to_systolic_factor * stroke_volume_actual
+        # diastolic_target = base_diastolic_reference + svr_to_diastolic_factor * (svr - 1.0)
+        expected_systolic_target = initial_diastolic + solver.sv_to_systolic_factor * expected_sv
+        expected_diastolic_target = 70.0 + solver.svr_to_diastolic_factor * (solver.svr - 1.0) # SVR is 1.0 by default
+
+        new_state_obj = solver.solve(initial_data.copy(), dt)
         new_state_dict = new_state_obj.state
 
-        # Assertions:
-        # 1. EDV should be relatively stable if edv_old = target_edv and filling_ratio = 1 (default)
-        #    dEDV/dt = (HR/60 * SV * (fill_ratio - 1)) + edv_recovery_rate * (target_edv - edv_old)
-        #    If edv_old = target_edv and fill_ratio = 1, then dEDV/dt = 0
-        self.assertAlmostEqual(new_state_dict["end_diastolic_volume"], initial_edv, delta=1.0, msg="EDV should be stable at target_edv")
+        # SBP should move towards its target
+        if expected_systolic_target > initial_systolic:
+            self.assertTrue(new_state_dict["systolic_bp"] > initial_systolic, "SBP should increase towards target")
+        elif expected_systolic_target < initial_systolic:
+            self.assertTrue(new_state_dict["systolic_bp"] < initial_systolic, "SBP should decrease towards target")
+        
+        # DBP should move towards its target
+        if expected_diastolic_target > initial_diastolic:
+            self.assertTrue(new_state_dict["diastolic_bp"] > initial_diastolic, "DBP should increase towards target")
+        elif expected_diastolic_target < initial_diastolic:
+            self.assertTrue(new_state_dict["diastolic_bp"] < initial_diastolic, "DBP should decrease towards target")
 
-        # 2. MAP will change because CO (75*70 = 5250 ml/min) is not perfectly balanced with SVR pressure (90 mmHg)
-        #    Let's check that it moves in the expected direction. CO > MAP/SVR (5250 > 90/1), so MAP should increase.
-        #    Initial MAP was 90.
-        self.assertTrue(new_state_dict["blood_pressure"] > 90.0, msg="MAP should increase slightly")
+        self.assertAlmostEqual(new_state_dict["end_diastolic_volume"], initial_edv, delta=1.0, msg="EDV should be stable at target_edv if filling_ratio=1")
+        
+        # HR should change based on baroreflex: map_setpoint (90) - initial_map (88.33) = 1.67
+        # dhr_dt = gain * diff = 0.1 * 1.67 = 0.167. So HR should increase slightly.
+        self.assertTrue(new_state_dict["heart_rate"] > initial_hr, msg="HR should increase slightly as MAP is below setpoint")
+        self.assertTrue(new_state_dict["systolic_bp"] > new_state_dict["diastolic_bp"])
 
-        # 3. HR should change due to baroreflex (MAP_setpoint - MAP_old)
-        #    Since initial MAP (90) is at setpoint, dHR/dt from baroreflex should be 0.
-        #    No epi. So HR should be stable.
-        self.assertAlmostEqual(new_state_dict["heart_rate"], initial_hr, delta=1.0, msg="HR should be relatively stable")
 
     def test_increased_preload_increases_sv_effect(self):
         solver = PressureHROxySolver()
-        initial_edv_baseline = solver.target_edv
+        initial_edv_baseline = solver.target_edv # 120
         initial_edv_increased = initial_edv_baseline + 40.0 # 160 mL
 
         base_data = {
-            "systolic_bp": 110.0, "diastolic_bp": 80.0, # MAP = 90 (setpoint)
+            "systolic_bp": 115.0, "diastolic_bp": 75.0, # MAP ~ 88.33
             "heart_rate": 75.0, "oxy_saturation": 98.0, "oxygen_debt": 0.0
         }
 
@@ -80,22 +86,32 @@ class TestPressureHROxySolver(unittest.TestCase):
         initial_data_increased_preload["end_diastolic_volume"] = initial_edv_increased
 
         dt = 1.0
-        state_baseline = solver.solve(initial_data_baseline, dt).state
-        state_increased_preload = solver.solve(initial_data_increased_preload, dt).state
+        state_baseline = solver.solve(initial_data_baseline.copy(), dt).state
+        state_increased_preload = solver.solve(initial_data_increased_preload.copy(), dt).state
 
-        # Increased preload (EDV) should lead to higher SV, thus higher CO, thus higher BP
-        self.assertTrue(state_increased_preload["blood_pressure"] > state_baseline["blood_pressure"],
-                        "MAP with increased preload should be higher than baseline MAP")
+        # Increased preload (EDV) should lead to higher SV, thus higher SBP primarily
+        delta_sbp_baseline = state_baseline["systolic_bp"] - base_data["systolic_bp"]
+        delta_dbp_baseline = state_baseline["diastolic_bp"] - base_data["diastolic_bp"]
+        
+        delta_sbp_increased = state_increased_preload["systolic_bp"] - base_data["systolic_bp"]
+        delta_dbp_increased = state_increased_preload["diastolic_bp"] - base_data["diastolic_bp"]
+
         self.assertTrue(state_increased_preload["systolic_bp"] > state_baseline["systolic_bp"],
-                        "Systolic BP with increased preload should be higher")
+                        "Systolic BP with increased preload should be higher than baseline's new SBP")
+        # Check that the change in SBP is more significant than DBP for the increased preload case
+        self.assertTrue(abs(delta_sbp_increased) > abs(delta_dbp_increased) or abs(delta_sbp_increased) > 0.1, # ensure some change if DBP is flat
+                        "With increased preload, SBP change should be more pronounced than DBP change.")
+        self.assertTrue(state_baseline["systolic_bp"] > state_baseline["diastolic_bp"])
+        self.assertTrue(state_increased_preload["systolic_bp"] > state_increased_preload["diastolic_bp"])
+
 
     def test_decreased_preload_decreases_sv_effect(self):
         solver = PressureHROxySolver()
-        initial_edv_baseline = solver.target_edv
-        initial_edv_decreased = initial_edv_baseline - 40.0 # 80 mL (must be > 30)
+        initial_edv_baseline = solver.target_edv # 120
+        initial_edv_decreased = initial_edv_baseline - 40.0 # 80 mL
 
         base_data = {
-            "systolic_bp": 110.0, "diastolic_bp": 80.0, # MAP = 90
+            "systolic_bp": 115.0, "diastolic_bp": 75.0, # MAP ~ 88.33
             "heart_rate": 75.0, "oxy_saturation": 98.0, "oxygen_debt": 0.0
         }
 
@@ -106,25 +122,27 @@ class TestPressureHROxySolver(unittest.TestCase):
         initial_data_decreased_preload["end_diastolic_volume"] = initial_edv_decreased
         
         dt = 1.0
-        state_baseline = solver.solve(initial_data_baseline, dt).state
-        state_decreased_preload = solver.solve(initial_data_decreased_preload, dt).state
+        state_baseline = solver.solve(initial_data_baseline.copy(), dt).state
+        state_decreased_preload = solver.solve(initial_data_decreased_preload.copy(), dt).state
+        
+        delta_sbp_decreased = state_decreased_preload["systolic_bp"] - base_data["systolic_bp"]
+        delta_dbp_decreased = state_decreased_preload["diastolic_bp"] - base_data["diastolic_bp"]
 
-        self.assertTrue(state_decreased_preload["blood_pressure"] < state_baseline["blood_pressure"],
-                        "MAP with decreased preload should be lower than baseline MAP")
         self.assertTrue(state_decreased_preload["systolic_bp"] < state_baseline["systolic_bp"],
-                        "Systolic BP with decreased preload should be lower")
+                        "Systolic BP with decreased preload should be lower than baseline's new SBP")
+        self.assertTrue(abs(delta_sbp_decreased) > abs(delta_dbp_decreased) or abs(delta_sbp_decreased) > 0.1,
+                        "With decreased preload, SBP change should be more pronounced than DBP change.")
+        self.assertTrue(state_baseline["systolic_bp"] > state_baseline["diastolic_bp"])
+        self.assertTrue(state_decreased_preload["systolic_bp"] > state_decreased_preload["diastolic_bp"])
+
 
     def test_increased_afterload_decreases_sv_effect(self):
+        # This test checks if increased MAP_old (afterload) correctly reduces SV,
+        # leading to a different evolution of BP compared to a baseline MAP_old.
         solver = PressureHROxySolver()
-        # Baseline: MAP = map_setpoint
-        # Increased afterload: MAP_old > map_setpoint
-        # SV calc uses map_old: SV = base + k_preload*(EDV-target) - k_afterload*(MAP_old - map_setpoint)
         
-        map_baseline = solver.map_setpoint # 90
-        map_increased_afterload = solver.map_setpoint + 20 # 110
-
-        # To achieve MAP of 110: SBP=150, DBP=95 => (150 + 190)/3 = 340/3 = 113. Close enough.
-        # Or SBP=130, DBP=100 => (130 + 200)/3 = 330/3 = 110
+        map_baseline_start = solver.map_setpoint # 90
+        map_increased_afterload_start = solver.map_setpoint + 20 # 110
         
         base_data = {
              "end_diastolic_volume": solver.target_edv, # 120
@@ -132,48 +150,42 @@ class TestPressureHROxySolver(unittest.TestCase):
         }
 
         initial_data_baseline = base_data.copy()
-        initial_data_baseline["systolic_bp"] = 110.0 # MAP = 90
-        initial_data_baseline["diastolic_bp"] = 80.0
+        initial_data_baseline["systolic_bp"] = 110.0 # SBP for MAP=90
+        initial_data_baseline["diastolic_bp"] = 80.0  # DBP for MAP=90
 
         initial_data_increased_afterload = base_data.copy()
-        initial_data_increased_afterload["systolic_bp"] = 130.0 # MAP = 110
-        initial_data_increased_afterload["diastolic_bp"] = 100.0
+        initial_data_increased_afterload["systolic_bp"] = 130.0 # SBP for MAP=110
+        initial_data_increased_afterload["diastolic_bp"] = 100.0 # DBP for MAP=110
         
         dt = 1.0
         
-        # Calculate CO for baseline:
-        # SV_baseline = base_sv + k_preload*(target_edv - target_edv) - k_afterload*(map_setpoint - map_setpoint) = base_sv (70)
-        # CO_baseline = 75 * 70 = 5250
         state_baseline_obj = solver.solve(initial_data_baseline.copy(), dt)
         map_new_baseline = state_baseline_obj.state["blood_pressure"]
+        sbp_new_baseline = state_baseline_obj.state["systolic_bp"]
+        dbp_new_baseline = state_baseline_obj.state["diastolic_bp"]
 
-        # Calculate CO for increased afterload:
-        # SV_increased_afterload = base_sv + 0 - k_afterload*(110 - 90) = 70 - 0.3*20 = 70 - 6 = 64
-        # CO_increased_afterload = 75 * 64 = 4800
         state_increased_afterload_obj = solver.solve(initial_data_increased_afterload.copy(), dt)
         map_new_increased_afterload = state_increased_afterload_obj.state["blood_pressure"]
+        sbp_new_increased_afterload = state_increased_afterload_obj.state["systolic_bp"]
+        dbp_new_increased_afterload = state_increased_afterload_obj.state["diastolic_bp"]
         
-        # dMAP/dt = (CO - MAP/SVR)/C.
-        # Baseline dMAP/dt approx (5250/60 - 90/1)/1 = (87.5 - 90)/1 = -2.5 (assuming C=1, SVR=1, and converting CO to per sec)
-        # Increased Afterload dMAP/dt approx (4800/60 - 110/1)/1 = (80 - 110)/1 = -30
-        # So, the new MAP in the "increased afterload" case should be lower than its own starting MAP,
-        # and potentially lower than the new MAP from baseline if the drop is significant.
-        # The key is that the *change* in MAP (dMAP_dt * dt) is more negative (or less positive).
-        
-        # New MAP for baseline will be initial_map + dmap_dt*dt = 90 + (-2.5 * 1) = 87.5
-        # New MAP for increased afterload = 110 + (-30*1) = 80
-        # This means map_new_increased_afterload (80) < map_new_baseline (87.5)
-        self.assertAlmostEqual(map_new_baseline, 87.5, delta=0.1) # Based on manual calculation
-        self.assertAlmostEqual(map_new_increased_afterload, 80.0, delta=0.1) # Based on manual calculation
+        # SV is reduced by higher map_old (110 vs 90).
+        # SV_baseline_calc = 70 (base) - 0.3*(90-90) = 70
+        # SV_increased_afterload_calc = 70 (base) - 0.3*(110-90) = 70 - 0.3*20 = 70 - 6 = 64
+        # This lower SV in the 'increased_afterload' case should generally lead to lower subsequent pressures,
+        # or at least a smaller increase if pressures are rising.
+        # The exact values are complex due to feedback, but the relative effect of SV should be observable.
+        self.assertTrue(map_new_increased_afterload < map_new_baseline + (map_increased_afterload_start - map_baseline_start) - 1.0, # Check relative change
+                        "New MAP with initially higher afterload (and thus lower SV) should be comparatively lower.")
+        self.assertTrue(sbp_new_baseline > dbp_new_baseline)
+        self.assertTrue(sbp_new_increased_afterload > dbp_new_increased_afterload)
 
-        self.assertTrue(map_new_increased_afterload < map_new_baseline,
-                        "New MAP with increased afterload should be lower than new MAP from baseline due to SV reduction.")
 
     def test_edv_dynamics_filling_ratio_gt_1(self):
         solver = PressureHROxySolver(filling_ratio_factor=1.2)
         initial_edv = solver.target_edv # 120
         initial_data = {
-            "systolic_bp": 110.0, "diastolic_bp": 80.0, # MAP = 90
+            "systolic_bp": 110.0, "diastolic_bp": 80.0, 
             "heart_rate": 75.0, "oxy_saturation": 98.0,
             "end_diastolic_volume": initial_edv,
             "oxygen_debt": 0.0
@@ -181,18 +193,20 @@ class TestPressureHROxySolver(unittest.TestCase):
         dt = 1.0
         new_state = solver.solve(initial_data.copy(), dt).state
         # dEDV/dt = (HR/60 * SV * (fill_ratio - 1)) + edv_recovery_rate * (target_edv - edv_old)
-        # SV at baseline EDV and MAP = base_stroke_volume (70)
+        # SV at baseline EDV and MAP (approx 90) = base_stroke_volume (70)
         # HR/60 * SV * (1.2 - 1.0) = (75/60) * 70 * 0.2 = 1.25 * 70 * 0.2 = 87.5 * 0.2 = 17.5
         # edv_recovery_rate * (target_edv - edv_old) = 0 since edv_old = target_edv
         # So, dEDV_dt = 17.5. edv_new = 120 + 17.5 * 1 = 137.5
         self.assertAlmostEqual(new_state["end_diastolic_volume"], 137.5, delta=0.1,
                                "EDV should increase with filling_ratio > 1")
+        self.assertTrue(new_state["systolic_bp"] > new_state["diastolic_bp"])
+
 
     def test_edv_dynamics_filling_ratio_lt_1(self):
         solver = PressureHROxySolver(filling_ratio_factor=0.8)
         initial_edv = solver.target_edv # 120
         initial_data = {
-            "systolic_bp": 110.0, "diastolic_bp": 80.0, # MAP = 90
+            "systolic_bp": 110.0, "diastolic_bp": 80.0,
             "heart_rate": 75.0, "oxy_saturation": 98.0,
             "end_diastolic_volume": initial_edv,
             "oxygen_debt": 0.0
@@ -205,6 +219,8 @@ class TestPressureHROxySolver(unittest.TestCase):
         # edv_new = 120 - 17.5 * 1 = 102.5
         self.assertAlmostEqual(new_state["end_diastolic_volume"], 102.5, delta=0.1,
                                "EDV should decrease with filling_ratio < 1")
+        self.assertTrue(new_state["systolic_bp"] > new_state["diastolic_bp"])
+
 
     def test_stroke_volume_max_clamp_effect(self):
         solver = PressureHROxySolver(
@@ -212,70 +228,174 @@ class TestPressureHROxySolver(unittest.TestCase):
             k_preload=2.0,
             max_stroke_volume=130.0, # Clamp here
             target_edv=120.0,
-            map_setpoint=90.0, # Keep other effects neutral
-            k_afterload=0.1 # Minimize afterload effect for this test
+            map_setpoint=90.0, 
+            k_afterload=0.1 
         )
         initial_edv = 140.0 # Preload: k_preload * (140-120) = 2.0 * 20 = 40
-        # Calculated SV before clamp: base_sv + 40 = 100 + 40 = 140 mL
-        # This should be clamped to max_stroke_volume = 130 mL
+        # Calculated SV before clamp: base_sv + 40 = 100 + 40 = 140 mL -> clamped to 130 mL
 
+        initial_sbp = 110.0
+        initial_dbp = 80.0 # MAP = 90
         initial_data = {
-            "systolic_bp": 110.0, "diastolic_bp": 80.0, # MAP = 90 (solver.map_setpoint)
-            "heart_rate": 60.0, # Use 60 BPM for easier CO calculation (1 BPS)
+            "systolic_bp": initial_sbp, "diastolic_bp": initial_dbp, 
+            "heart_rate": 60.0, 
             "oxy_saturation": 98.0,
             "end_diastolic_volume": initial_edv,
             "oxygen_debt": 0.0
         }
         
-        # Expected CO with clamping: HR_bps * clamped_SV = (60/60) * 130 = 130 mL/s
-        # Expected dMAP_dt = (CO_clamped - MAP/SVR) / C
-        # = (130 - 90/1) / 1 = 40 (assuming C=1, SVR=1 from defaults)
-        # Expected new_map = 90 + 40 * 1.0 = 130
-
         dt = 1.0
         new_state = solver.solve(initial_data.copy(), dt).state
-        self.assertAlmostEqual(new_state["blood_pressure"], 130.0, delta=0.1,
-                               "MAP should reflect max_stroke_volume clamping")
+        
+        # Expected change with SV = 130 mL
+        # systolic_target = initial_dbp + sv_factor * SV_clamped = 80 + 0.5 * 130 = 80 + 65 = 145
+        # systolic_change_potential = 145 - 110 = 35
+        # systolic_rate_of_change = 35 / (compliance * 5.0) = 35 / 5 = 7
+        # new_sbp = 110 + 7 * 1 = 117
+        self.assertAlmostEqual(new_state["systolic_bp"], 117.0, delta=0.1,
+                               "SBP should reflect max_stroke_volume clamping effect on systolic_target")
+        self.assertTrue(new_state["systolic_bp"] > new_state["diastolic_bp"])
+
 
     def test_stroke_volume_min_clamp_effect(self):
         solver = PressureHROxySolver(
             base_stroke_volume=10.0,
             k_afterload=0.5,
-            target_edv=120.0, # Keep preload neutral
+            target_edv=120.0, 
             map_setpoint=90.0,
-            k_preload=0.1 # Minimize preload effect
+            k_preload=0.1 
         )
         # SV = base (10) + k_preload*(EDV-target) - k_afterload*(MAP_old - map_setpoint)
-        # To trigger min clamp (5mL):
-        # Let EDV = target_edv (120mL) -> preload effect = 0
-        # We need base_sv - k_afterload*(MAP_old - map_setpoint) < 5
-        # 10 - 0.5 * (MAP_old - 90) < 5
-        # -0.5 * (MAP_old - 90) < -5
-        # (MAP_old - 90) > 10
-        # MAP_old > 100. Let MAP_old = 120.
-        # Afterload term: 0.5 * (120 - 90) = 0.5 * 30 = 15
+        # MAP_old = 120. Afterload term: 0.5 * (120 - 90) = 15
         # Calculated SV before clamp: 10 - 15 = -5 mL. Should be clamped to 5 mL.
 
-        initial_map_for_high_afterload = 120.0
-        # SBP=160, DBP=100 => (160+200)/3 = 360/3 = 120
+        initial_sbp = 160.0
+        initial_dbp = 100.0 # MAP = 120
         initial_data = {
-            "systolic_bp": 160.0, 
-            "diastolic_bp": 100.0, # MAP = 120
-            "heart_rate": 60.0, # 1 BPS
+            "systolic_bp": initial_sbp, 
+            "diastolic_bp": initial_dbp, 
+            "heart_rate": 60.0, 
             "oxy_saturation": 98.0,
-            "end_diastolic_volume": solver.target_edv, # 120, no preload effect
+            "end_diastolic_volume": solver.target_edv, 
             "oxygen_debt": 0.0
         }
 
-        # Expected CO with clamping: HR_bps * clamped_SV = (60/60) * 5 = 5 mL/s
-        # Expected dMAP_dt = (CO_clamped - MAP/SVR) / C
-        # = (5 - 120/1) / 1 = -115 (assuming C=1, SVR=1 from defaults)
-        # Expected new_map = 120 + (-115) * 1.0 = 5
-
         dt = 1.0
         new_state = solver.solve(initial_data.copy(), dt).state
-        self.assertAlmostEqual(new_state["blood_pressure"], 5.0, delta=0.1,
-                               "MAP should reflect min_stroke_volume clamping")
+
+        # Expected change with SV = 5 mL
+        # systolic_target = initial_dbp + sv_factor * SV_clamped = 100 + 0.5 * 5 = 100 + 2.5 = 102.5
+        # systolic_change_potential = 102.5 - 160 = -57.5
+        # systolic_rate_of_change = -57.5 / 5.0 = -11.5
+        # new_sbp = 160 - 11.5 * 1 = 148.5
+        self.assertAlmostEqual(new_state["systolic_bp"], 148.5, delta=0.1,
+                               "SBP should reflect min_stroke_volume clamping effect on systolic_target")
+        self.assertTrue(new_state["systolic_bp"] > new_state["diastolic_bp"])
+
+
+    def test_stroke_volume_effect_on_systolic(self):
+        solver = PressureHROxySolver() # Defaults: sv_to_systolic_factor=0.5, compliance=1.0
+        dt = 1.0
+        base_hr = 60.0
+        base_diastolic = 70.0 # Keep DBP somewhat stable initially for isolating SBP effect
+
+        # Scenario 1: Baseline SV
+        edv1 = solver.target_edv # 120 mL
+        # SV1 = base_sv (70) - k_afterload*(map_at_70_dbp - map_setpoint)
+        # Assuming SBP around 110 for DBP 70, MAP = (110+140)/3 = 250/3 = 83.33
+        # SV1 = 70 - 0.3*(83.33-90) = 70 - 0.3*(-6.67) = 70 + 2 = 72
+        initial_data1 = {"systolic_bp": 110.0, "diastolic_bp": base_diastolic, "heart_rate": base_hr, "end_diastolic_volume": edv1, "oxy_saturation": 98.0}
+        state1 = solver.solve(initial_data1.copy(), dt).state
+        sbp1, dbp1 = state1["systolic_bp"], state1["diastolic_bp"]
+
+        # Scenario 2: Higher SV
+        edv2 = solver.target_edv + 20 # 140 mL
+        # SV2 approx SV1 + k_preload*20 = 72 + 0.5*20 = 72 + 10 = 82
+        initial_data2 = {"systolic_bp": 110.0, "diastolic_bp": base_diastolic, "heart_rate": base_hr, "end_diastolic_volume": edv2, "oxy_saturation": 98.0}
+        state2 = solver.solve(initial_data2.copy(), dt).state
+        sbp2, dbp2 = state2["systolic_bp"], state2["diastolic_bp"]
+        
+        self.assertTrue(sbp2 > sbp1, "SBP with higher SV should be greater than SBP with baseline SV")
+        self.assertAlmostEqual(dbp2, dbp1, delta=2.0, "DBP should remain relatively unchanged with SV change") # DBP might change a bit due to SBP link
+        self.assertTrue(state1["systolic_bp"] > state1["diastolic_bp"])
+        self.assertTrue(state2["systolic_bp"] > state2["diastolic_bp"])
+
+        # Scenario 3: Lower SV
+        edv3 = solver.target_edv - 20 # 100 mL
+        # SV3 approx SV1 - k_preload*20 = 72 - 10 = 62
+        initial_data3 = {"systolic_bp": 110.0, "diastolic_bp": base_diastolic, "heart_rate": base_hr, "end_diastolic_volume": edv3, "oxy_saturation": 98.0}
+        state3 = solver.solve(initial_data3.copy(), dt).state
+        sbp3, dbp3 = state3["systolic_bp"], state3["diastolic_bp"]
+
+        self.assertTrue(sbp3 < sbp1, "SBP with lower SV should be less than SBP with baseline SV")
+        self.assertAlmostEqual(dbp3, dbp1, delta=2.0, "DBP should remain relatively unchanged with SV change")
+        self.assertTrue(state3["systolic_bp"] > state3["diastolic_bp"])
+
+
+    def test_svr_effect_on_diastolic(self):
+        solver = PressureHROxySolver() # Defaults: svr_to_diastolic_factor=50.0, compliance=1.0
+        dt = 1.0
+        base_sbp = 120.0
+        base_dbp = 80.0 # Initial DBP
+        base_edv = solver.target_edv
+
+        # Scenario 1: Baseline SVR
+        solver.svr = 1.0
+        initial_data1 = {"systolic_bp": base_sbp, "diastolic_bp": base_dbp, "heart_rate": 75.0, "end_diastolic_volume": base_edv, "oxy_saturation": 98.0}
+        state1 = solver.solve(initial_data1.copy(), dt).state
+        sbp1, dbp1 = state1["systolic_bp"], state1["diastolic_bp"]
+
+        # Scenario 2: Higher SVR
+        solver.svr = 1.2 # 20% increase
+        initial_data2 = {"systolic_bp": base_sbp, "diastolic_bp": base_dbp, "heart_rate": 75.0, "end_diastolic_volume": base_edv, "oxy_saturation": 98.0}
+        state2 = solver.solve(initial_data2.copy(), dt).state
+        sbp2, dbp2 = state2["systolic_bp"], state2["diastolic_bp"]
+
+        self.assertTrue(dbp2 > dbp1, "DBP with higher SVR should be greater than DBP with baseline SVR")
+        # SBP might also change due to SVR's effect on afterload (reducing SV) or DBP feedback.
+        # diastolic_target for svr=1.0 is 70.0 + 50*(1-1) = 70.0
+        # diastolic_target for svr=1.2 is 70.0 + 50*(1.2-1) = 70 + 50*0.2 = 70 + 10 = 80.0
+        # Initial DBP is 80. So for SVR=1.2, DBP should stay close to 80 or move slightly towards it.
+        # For SVR=1.0, DBP (80) should move towards 70. So dbp2 (SVR 1.2) > dbp1 (SVR 1.0) is expected.
+        self.assertTrue(state1["systolic_bp"] > state1["diastolic_bp"])
+        self.assertTrue(state2["systolic_bp"] > state2["diastolic_bp"])
+
+        # Scenario 3: Lower SVR
+        solver.svr = 0.8 # 20% decrease
+        initial_data3 = {"systolic_bp": base_sbp, "diastolic_bp": base_dbp, "heart_rate": 75.0, "end_diastolic_volume": base_edv, "oxy_saturation": 98.0}
+        state3 = solver.solve(initial_data3.copy(), dt).state
+        sbp3, dbp3 = state3["systolic_bp"], state3["diastolic_bp"]
+        
+        self.assertTrue(dbp3 < dbp1, "DBP with lower SVR should be less than DBP with baseline SVR")
+        # diastolic_target for svr=0.8 is 70.0 + 50*(0.8-1) = 70 - 50*0.2 = 70 - 10 = 60.0
+        # So dbp3 (SVR 0.8, target 60) < dbp1 (SVR 1.0, target 70) is expected.
+        self.assertTrue(state3["systolic_bp"] > state3["diastolic_bp"])
+
+
+    def test_epinephrine_effect(self):
+        solver = PressureHROxySolver(epi_bp_factor=0.3) # Default epi_bp_factor
+        dt = 1.0
+        initial_data_no_epi = {
+            "systolic_bp": 120.0, "diastolic_bp": 80.0, "heart_rate": 70.0, 
+            "end_diastolic_volume": solver.target_edv, "oxy_saturation": 98.0,
+            "epinephrine": 0.0 # Explicitly zero
+        }
+        state_no_epi = solver.solve(initial_data_no_epi.copy(), dt).state
+        sbp_no_epi, dbp_no_epi = state_no_epi["systolic_bp"], state_no_epi["diastolic_bp"]
+
+        initial_data_with_epi = initial_data_no_epi.copy()
+        initial_data_with_epi["epinephrine"] = 1.0 # Arbitrary unit of epi
+        
+        state_with_epi = solver.solve(initial_data_with_epi.copy(), dt).state
+        sbp_with_epi, dbp_with_epi = state_with_epi["systolic_bp"], state_with_epi["diastolic_bp"]
+
+        # epi_bp_factor (0.3) is split for SBP and DBP, so 0.15 effective factor for each per dt
+        # Change due to epi should be positive: (0.15 / (compliance*5)) * dt if it were main driver.
+        # More simply, epi adds a positive term to both SBP and DBP calculations.
+        self.assertTrue(sbp_with_epi > sbp_no_epi, "SBP should increase with epinephrine")
+        self.assertTrue(dbp_with_epi > dbp_no_epi, "DBP should increase with epinephrine")
+        self.assertTrue(state_no_epi["systolic_bp"] > state_no_epi["diastolic_bp"])
+        self.assertTrue(state_with_epi["systolic_bp"] > state_with_epi["diastolic_bp"])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This implements a new model for systolic and diastolic blood pressure calculation within the PressureHROxySolver.

Key changes:
- Systolic blood pressure (SBP) is now primarily driven by stroke volume (SV) acting on the current diastolic blood pressure (DBP). A new parameter `sv_to_systolic_factor` (mmHg/mL) quantifies this.
- Diastolic blood pressure (DBP) is now primarily driven by systemic vascular resistance (SVR). A new parameter `svr_to_diastolic_factor` (mmHg/SVR unit) quantifies this against a base diastolic reference.
- The previous `pulse_pressure_factor` has been removed.
- Mean Arterial Pressure (MAP) is derived from the newly calculated SBP and DBP.
- The rate of change towards target SBP and DBP is moderated by arterial compliance.
- Epinephrine effects (`epi_bp_factor`) are now distributed to influence both SBP and DBP target calculations.

Testing:
- Existing tests in `tests/test_pressure_hr_oxy_solver.py` have been updated to reflect the new mechanics.
- New tests were added to specifically validate:
    - The impact of SV changes on SBP.
    - The impact of SVR changes on DBP.
    - The combined effect of epinephrine on both SBP and DBP.
- Default values for the new factors have been established and are used in the updated tests.